### PR TITLE
Fix install.sh for Merlin Routers

### DIFF
--- a/server/install.sh
+++ b/server/install.sh
@@ -27,18 +27,16 @@ if [ $? -ne 0 ]; then
 else 
     echo "Entware is installed"
 fi
-lighttpd -v > /dev/null 2>&1
-if [ $? -ne 0 ]; then
-    echo "Installing lighttpd ..."
+if [ ! -x /opt/sbin/lighttpd ] || ! opkg list-installed | grep -q "^lighttpd "; then
+    echo "Installing lighttpd (Entware build) ..."
     opkg install lighttpd
-else 
-    echo "lighttpd is installed"
+else
+    echo "lighttpd (Entware) is already installed"
 fi
-bc -v > /dev/null 2>&1
-if [ $? -ne 0 ]; then
+if ! bc -v >/dev/null 2>&1; then
     echo "Installing bc ..."
     opkg install bc
-else 
+else
     echo "bc is installed"
 fi
 fc status > /dev/null 2>&1

--- a/server/install.sh
+++ b/server/install.sh
@@ -27,7 +27,7 @@ if [ $? -ne 0 ]; then
 else 
     echo "Entware is installed"
 fi
-if [ ! -x /opt/sbin/lighttpd ] || ! opkg list-installed | grep -q "^lighttpd "; then
+if [ ! -x /opt/sbin/lighttpd ] || ! opkg list-installed lighttpd > /dev/null 2>&1; then
     echo "Installing lighttpd (Entware build) ..."
     opkg install lighttpd
 else


### PR DESCRIPTION
Fix Installer as per https://www.snbforums.com/threads/how-to-install-yamon-on-asuswrt-merlin.95028/post-959711

Issues:
1. Merlin ships with lighttpd built-in. We specifically want to install the Entware version, but the existing check passes with the built-in version and never installs the Entware version.
2. Due to set -e; the bc will exit before reaching the if statement. To resolve don't seperate bc -v command (returns 127 when bc is missing)